### PR TITLE
Fix navbar link movement on hover

### DIFF
--- a/src/component/Navbar.js
+++ b/src/component/Navbar.js
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
     color: "white",
     fontSize: "20px",
     marginLeft: theme.spacing(20),
+    borderBottom: "1px solid transparent",
     "&:hover": {
       color: "yellow",
       borderBottom: "1px solid white",


### PR DESCRIPTION
This pull request addresses the issue https://github.com/dharmelolar/material-UI-navbar/issues/1  by updating the navbar styles to prevent link movement on hover. Specifically, I changed the link style to include a transparent border-bottom, and added a hover style to change the color to yellow and add a white border-bottom. These changes ensure that the navbar links remain in a fixed position when hovered over.